### PR TITLE
ansible-silverblue-flatpaks.jinja2: Return 0

### DIFF
--- a/ansible-silverblue/roles/flatpaks/templates/ansible-silverblue-flatpaks.jinja2
+++ b/ansible-silverblue/roles/flatpaks/templates/ansible-silverblue-flatpaks.jinja2
@@ -82,7 +82,7 @@ echo "# Installing {{ item.name }}"
 if [ "$?" != 0 ] ; then
         zenity --error \
           --text="Installing {{ item.name }} Failed"
-        exit 1
+        return 0
 fi
 {% set progress_count.value = progress_count.value + 2 %}
 echo "{{ progress_count.value }}"


### PR DESCRIPTION
I want the script to print that the installation failed, but continue.